### PR TITLE
Port to Owens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Changes:
+
+  - Updated to run jobs on Owens cluster.
+
 ## 0.1.1 (2017-06-23)
 
 Features:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub License](https://img.shields.io/github/license/osc/bc_osc_comsol.svg)
 
 A Batch Connect app designed for OSC OnDemand that launches COMSOL Multiphysics
-within an Oakley batch job.
+within an Owens batch job.
 
 ## Prerequisites
 

--- a/form.yml
+++ b/form.yml
@@ -26,12 +26,7 @@ attributes:
       - ["any", ":ppn=28"]
       - ["vis", ":ppn=28:vis:gpus=1"]
       - ["hugemem", ":ppn=48:hugemem"]
-  version:
-    widget: select
-    label: "COMSOL Multiphysics version"
-    help: "This defines the version of COMSOL you want to load."
-    options:
-      - ["5.2a", "comsol/52a"]
+  version: "comsol/52a"
 form:
   - version
   - bc_num_hours

--- a/form.yml
+++ b/form.yml
@@ -1,8 +1,8 @@
 ---
 title: "COMSOL Multiphysics"
-cluster: "oakley"
+cluster: "owens"
 description: |
-  This app will launch a COMSOL Multiphysics GUI on one or more Oakley nodes.
+  This app will launch a COMSOL Multiphysics GUI on one or more Owens nodes.
   You will be able to interact with the COMSOL GUI through a VNC session.
 attributes:
   bc_vnc_resolution:
@@ -13,30 +13,25 @@ attributes:
     widget: select
     label: "Node type"
     help: |
-      - **any** - (*12 cores*) Chooses anyone of the available Oakley nodes.
-        This reduces the wait time as you have no requirements.
-      - **vis** - (*12 cores*) This node includes an NVIDIA Tesla M2070 GPU
+      - **any** - (*28 cores*) Use any available Owens node. This reduces the
+        wait time as there are no node requirements.
+      - **vis** - (*28 cores*) This node includes an NVIDIA Tesla P100 GPU
         with an X server running in the background. This allows for Hardware
         Rendering with the GPU typically needed for 3D visualization using
-        VirtualGL. There are currently only 128 of these nodes on Oakley.
-      - **bigmem** - (*12 cores*) This Oakley node comes with 192GB of
-        available RAM. There are only 8 of these nodes on Oakley.
-      - **hugemem** - (*32 cores*) This Oakley node has 1TB of available RAM as
-        well as 32 cores. There is only 1 of these nodes on Oakley. A
-        reservation may be required to use this node.
+        VirtualGL. There are currently only 160 of these nodes on Owens.
+      - **hugemem** - (*48 cores*) Use an Owens node that has 1.5TB of
+        available RAM as well as 48 cores. There are 16 of these nodes on
+        Owens.
     options:
-      - ["any", ":ppn=12"]
-      - ["vis", ":ppn=12:vis:gpus=1"]
-      - ["bigmem", ":ppn=12:bigmem"]
-      - ["hugemem", ":ppn=32:hugemem"]
+      - ["any", ":ppn=28"]
+      - ["vis", ":ppn=28:vis:gpus=1"]
+      - ["hugemem", ":ppn=48:hugemem"]
   version:
     widget: select
     label: "COMSOL Multiphysics version"
     help: "This defines the version of COMSOL you want to load."
     options:
-      - ["5.1", "comsol/51"]
       - ["5.2a", "comsol/52a"]
-      - ["5.3", "comsol/53"]
 form:
   - version
   - bc_num_hours


### PR DESCRIPTION
Ported to Owens.

Only COMSOL 52a is available on Owens, so we only have that option here.

Testing is not complete as the Comsol software flag is in use at the time of PR. Will need to test during off-hours.